### PR TITLE
Only log to tensorboard if gpu_rank = 0

### DIFF
--- a/bert/models/reporter.py
+++ b/bert/models/reporter.py
@@ -276,7 +276,6 @@ class Statistics(object):
         """ display statistics to tensorboard """
         from torch.distributed import get_rank
         gpu_rank = get_rank()
-        print(f'gpu_rank in log : {gpu_rank}')
         if gpu_rank != 0:
             return
         t = self.elapsed_time()

--- a/bert/models/reporter.py
+++ b/bert/models/reporter.py
@@ -274,6 +274,11 @@ class Statistics(object):
 
     def log_tensorboard(self, prefix, writer, learning_rate, step):
         """ display statistics to tensorboard """
+        from torch.distributed import get_rank
+        gpu_rank = get_rank()
+        print(f'gpu_rank in log : {gpu_rank}')
+        if gpu_rank != 0:
+            return
         t = self.elapsed_time()
         writer.add_scalar(prefix + "/xent", self.xent(), step)
         writer.add_scalar(prefix + "/ppl", self.ppl(), step)

--- a/bert/models/z_trainer.py
+++ b/bert/models/z_trainer.py
@@ -384,7 +384,7 @@ class Trainer(object):
         Simple function to report training stats (if report_manager is set)
         see `onmt.utils.ReportManagerBase.report_training` for doc
         """
-        if self.report_manager is not None:
+        if self.report_manager is not None and self.gpu_rank == 0:
             return self.report_manager.report_training(
                 step, num_steps, learning_rate, report_stats,
                 multigpu=self.n_gpu > 1)
@@ -395,7 +395,7 @@ class Trainer(object):
         Simple function to report stats (if report_manager is set)
         see `onmt.utils.ReportManagerBase.report_step` for doc
         """
-        if self.report_manager is not None:
+        if self.report_manager is not None and self.gpu_rank == 0:
             return self.report_manager.report_step(
                 learning_rate, step, train_stats=train_stats,
                 valid_stats=valid_stats)

--- a/bert/models/z_trainer.py
+++ b/bert/models/z_trainer.py
@@ -384,7 +384,7 @@ class Trainer(object):
         Simple function to report training stats (if report_manager is set)
         see `onmt.utils.ReportManagerBase.report_training` for doc
         """
-        if self.report_manager is not None and self.gpu_rank == 0:
+        if self.report_manager is not None:
             return self.report_manager.report_training(
                 step, num_steps, learning_rate, report_stats,
                 multigpu=self.n_gpu > 1)
@@ -395,7 +395,7 @@ class Trainer(object):
         Simple function to report stats (if report_manager is set)
         see `onmt.utils.ReportManagerBase.report_step` for doc
         """
-        if self.report_manager is not None and self.gpu_rank == 0:
+        if self.report_manager is not None:
             return self.report_manager.report_step(
                 learning_rate, step, train_stats=train_stats,
                 valid_stats=valid_stats)


### PR DESCRIPTION
This should fix whacky lines in TensorBoard reports. We still have to gather the distributed stats as otherwise there are concurrency issues.